### PR TITLE
Give feedback if committer name doesn't exist

### DIFF
--- a/git-game
+++ b/git-game
@@ -97,7 +97,7 @@ loop do
     guess = gets
   end
 
-  if author.downcase.include?(guess.strip.downcase) && !guess.strip.empty?
+  if author.downcase.start_with?(guess.strip.downcase) && !guess.strip.empty?
     streak += 1
     puts "Got it!"
   else

--- a/git-game
+++ b/git-game
@@ -87,7 +87,12 @@ loop do
 
   guess = gets
 
-  while guess.strip.empty?
+  while guess.strip.empty? || !committers.map { |c| c.downcase.start_with?(guess.strip.downcase) }.any?
+    if guess.strip.empty?
+      print "Guess was empty, try again\n"
+    elsif !committers.map { |c| c.downcase.start_with?(guess.strip.downcase) }.any?
+      print "'#{guess.strip}' didn't exist in committers: #{committers.join(", ")}\n"
+    end
     print "Who wrote it (current streak: #{streak})? "
     guess = gets
   end


### PR DESCRIPTION
Don't really like adding the line terminators, but it seemed like the only way to get the formatting right.

It's probably also terribly ugly in repos with lots of committers.
