### PR TITLE
Remove unecessary condition in if

### DIFF
--- a/git-game
+++ b/git-game
@@ -92,7 +92,7 @@ loop do
     guess = gets
   end
 
-  if author.downcase.include?(guess.strip.downcase) && !guess.strip.empty?
+  if author.downcase.include?(guess.strip.downcase)
     streak += 1
     puts "Got it!"
   else


### PR DESCRIPTION
The previous while loop should ensure that `guess.strip.empty? == false`.

(Not 100% sure if this is correct, but I think so)
