### PR TITLE
Mailmap Support and Other Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What is it?
 
-In the git game, you  guess who made a commit to your team's repo based on their commit message:
+In the git game, you guess who made a commit to your team's repo based on their commit message:
 
 ![](https://cloud.githubusercontent.com/assets/21294/6428030/ba13a98c-bf60-11e4-92fa-ae25302e9a84.png)
 
@@ -13,7 +13,7 @@ The goal is to get the longest streak! (It's harder than you think...)
 - [Download the `git-game` executable](https://github.com/jsomers/git-game/releases/tag/1.2)
 - Put it somewhere on your PATH (like /usr/local/bin)
 - Then, in any git repository, run `git game`
-- (If you'd like, you can select a subset of commits, for example, `git game --after={2014-08-08}`. For more options, see [http://gitref.org/inspect/](http://gitref.org/inspect/).)
+- (If you'd like, you can select a subset of commits, for example, `git game --after={2014-08-08}`. For more options, see [Git - git-log documentation](https://git-scm.com/docs/git-log).)
 
 ## Requirements
 

--- a/git-game
+++ b/git-game
@@ -10,21 +10,26 @@ Signal.trap('INT') do
 end
 
 def print_header
-  puts '----------------------------------------------------------'
-  puts '                      THE GIT GAME                        '
-  puts '----------------------------------------------------------'
-  puts 'Welcome! The goal of the git game is to guess committers'
-  puts "based on their commit messages.\n\n"
+  puts <<~TXT
+    ----------------------------------------------------------
+                          THE GIT GAME
+    ----------------------------------------------------------
+    Welcome! The goal of the git game is to guess committers
+    based on their commit messages.
+
+  TXT
 end
 
 def print_help
-  puts '----------------------------------------------------------'
-  puts '                          USAGE                           '
-  puts '----------------------------------------------------------'
-  puts 'git game [extra git log options]'
-  puts 'EX: git game --after={2014-08-08}'
-  puts '(This script already uses --no-merges and --pretty.'
-  puts 'For more valid options see: http://gitref.org/inspect/)'
+  puts <<~TXT
+    ----------------------------------------------------------
+                              USAGE
+    ----------------------------------------------------------
+    git game [extra git log options]
+    EX: git game --after={2014-08-08}
+    (This script already uses --no-merges and --pretty.
+    For more valid options see: https://git-scm.com/docs/git-log)
+  TXT
 end
 
 # -- Usage Text --
@@ -33,7 +38,7 @@ if ARGV.count.positive?
   input = ARGV.shift
 
   case input
-  when 'help'
+  when 'help', '--help', '-h'
     print_header
     print_help
     exit 0
@@ -59,7 +64,6 @@ committers.each do |committer|
 end
 
 puts 'Ready? PRESS ENTER TO START PLAYING (Ctrl-C to quit)'
-
 gets
 
 system('clear')
@@ -67,12 +71,11 @@ system('clear')
 # -- Game loop --
 NUM_CHOICE = 4
 
-loop do
-  sha = commit_shas.pop
+commit_shas.each do |sha|
+  puts `git show #{sha} --pretty='(%ar)%n%B' --shortstat`
+  puts "\n\n"
+
   author = `git show #{sha} --pretty=%aN --no-patch`.strip
-
-  puts `git show #{sha} --pretty='(%ar)%n%B' --shortstat\n\n`
-
   choices = [author]
   choices += committers.reject do |name|
     name == author
@@ -82,10 +85,7 @@ loop do
     puts "[#{index + 1}] #{name}"
   end
 
-  print "Who wrote it (current streak: #{streak})? "
-
-  guess = gets.strip
-
+  guess = nil
   until guess.to_i.between?(1, NUM_CHOICE)
     print "Who wrote it (current streak: #{streak})? "
     guess = gets.strip
@@ -104,3 +104,10 @@ loop do
   sleep 1
   system('clear')
 end
+
+puts <<~TXT
+  Congratulations! There are no more commits in this repo!
+
+  Longest streak: #{longest_streak}
+TXT
+exit 0

--- a/git-game
+++ b/git-game
@@ -41,13 +41,10 @@ if ARGV.count.positive?
 end
 
 # -- Fetch Repository Info --
-COMMIT_DELIMITER = "\0"
-
 commit_shas = `git log --no-merges --pretty=%H -z #{input}`
-              .split(COMMIT_DELIMITER)
-committers = `git log --pretty=%aN -z`
-             .split(COMMIT_DELIMITER)
-             .uniq
+              .split("\0")
+committers = `git log --no-merges --pretty=%aN | sort -u`
+             .split("\n")
 
 # -- Show welcome message --
 system('clear')
@@ -73,18 +70,14 @@ loop do
   sha = commit_shas.shuffle.pop
   author = `git show #{sha} --pretty=%aN --no-patch`
 
-  puts `git show #{sha} --pretty='(%ar)%n%B' --shortstat`
-  puts
-  puts
+  puts `git show #{sha} --pretty='(%ar)%n%B' --shortstat\n\n`
 
-  choices = committers.sample(NUM_CHOICE)
-  unless choices.include?(author)
-    choices.pop
-    choices.push author
-  end
-  choices.shuffle!
+  choices = [author]
+  choices += committers.reject do |name|
+    name == author
+  end.sample(NUM_CHOICE - 1)
 
-  choices.each_with_index do |name, index|
+  choices.shuffle.each_with_index do |name, index|
     puts "[#{index + 1}] #{name}"
   end
 
@@ -92,7 +85,7 @@ loop do
 
   guess = gets.strip
 
-  while guess.empty? || !guess.to_i.between?(1, NUM_CHOICE)
+  until guess.to_i.between?(1, NUM_CHOICE)
     print "Who wrote it (current streak: #{streak})? "
     guess = gets.strip
   end

--- a/git-game
+++ b/git-game
@@ -43,6 +43,7 @@ end
 # -- Fetch Repository Info --
 commit_shas = `git log --no-merges --pretty=%H -z #{input}`
               .split("\0")
+              .shuffle
 committers = `git log --no-merges --pretty=%aN | sort -u`
              .split("\n")
 
@@ -67,8 +68,8 @@ system('clear')
 NUM_CHOICE = 4
 
 loop do
-  sha = commit_shas.shuffle.pop
-  author = `git show #{sha} --pretty=%aN --no-patch`
+  sha = commit_shas.pop
+  author = `git show #{sha} --pretty=%aN --no-patch`.strip
 
   puts `git show #{sha} --pretty='(%ar)%n%B' --shortstat\n\n`
 

--- a/git-game
+++ b/git-game
@@ -4,6 +4,7 @@
 require 'English'
 
 longest_streak = streak = 0
+difficulty = :normal
 
 # -- Exit gracefully --
 Signal.trap('INT') do
@@ -27,25 +28,44 @@ def print_help
     ----------------------------------------------------------
                               USAGE
     ----------------------------------------------------------
-    git game [extra git log options]
+    git game [options]
+
+    Flags:
+      -h, --help      Show this help message
+      --hard          Opt into a challenge (git game classic)
+
+    Extra options can be passed directly to git log:
+
     EX: git game --after={2014-08-08}
     (This script already uses --no-merges and --pretty.
     For more valid options see: https://git-scm.com/docs/git-log)
   TXT
 end
 
-# -- Usage Text --
-input = nil
-if ARGV.count.positive?
-  input = ARGV.shift
+def print_commit_preview(sha, difficulty)
+  details_args = {
+    normal: "--pretty='(%ar)%n%B' --shortstat",
+    hard: "--pretty='(%ar)%n%B' --no-patch"
+  }[difficulty]
 
-  case input
-  when 'help', '--help', '-h'
-    print_header
-    print_help
-    exit 0
-  end
+  puts `git show #{sha} #{details_args}`
+  puts "\n\n"
 end
+
+# -- Command line options --
+used_args = []
+if ARGV.include?('help') ||
+   ARGV.include?('--help') ||
+   ARGV.include?('-h')
+  print_header
+  print_help
+  exit 0
+elsif ARGV.include?('--hard')
+  used_args << '--hard'
+  difficulty = :hard
+end
+input = ARGV.reject { |arg| used_args.include?(arg) }.join(' ')
+ARGV.clear
 
 # -- Fetch Repository Info --
 commit_shas = `git log --no-merges --pretty=%H -z #{input}`
@@ -76,8 +96,7 @@ system('clear')
 NUM_CHOICE = 4
 
 commit_shas.each do |sha|
-  puts `git show #{sha} --pretty='(%ar)%n%B' --shortstat`
-  puts "\n\n"
+  print_commit_preview(sha, difficulty)
 
   author = `git show #{sha} --pretty=%aN --no-patch`.strip
   choices = [author]

--- a/git-game
+++ b/git-game
@@ -40,36 +40,20 @@ if ARGV.count.positive?
   end
 end
 
-# -- Parse commits --
-COMMIT_DELIMITER = 'XXXCOMMITXXX'
-FIELD_DELIMITER = ',,,'
+# -- Fetch Repository Info --
+COMMIT_DELIMITER = "\0"
 
-commit_format = ['%aN', '%ar', '%B', ''].join(FIELD_DELIMITER)
-
-raw_commits = `git log --no-merges --pretty=#{COMMIT_DELIMITER}#{commit_format} --shortstat #{input}`
+commit_shas = `git log --no-merges --pretty=%H -z #{input}`
               .split(COMMIT_DELIMITER)
-commits = []
-committers = []
-raw_commits.each do |com|
-  next if com.strip.empty?
-
-  fields = com.split(FIELD_DELIMITER)
-  next if fields.any?(&:empty?)
-
-  committers |= [fields[0]]
-  commits << {
-    author: fields[0],
-    date: fields[1],
-    message: fields[2],
-    stat: fields[3]
-  }
-end
+committers = `git log --pretty=%aN -z`
+             .split(COMMIT_DELIMITER)
+             .uniq
 
 # -- Show welcome message --
 system('clear')
 
 print_header
-puts "You're playing in a repo with #{commits.size} commits and #{committers.size}"
+puts "You're playing in a repo with #{commit_shas.size} commits and #{committers.size}"
 puts "distinct committers.\n\n"
 
 committers.each do |committer|
@@ -86,12 +70,10 @@ system('clear')
 NUM_CHOICE = 4
 
 loop do
-  commit = commits.shuffle.pop
-  author = commit[:author]
+  sha = commit_shas.shuffle.pop
+  author = `git show #{sha} --pretty=%aN --no-patch`
 
-  puts "(#{commit[:date]})\n"
-  puts commit[:message]
-  puts commit[:stat]
+  puts `git show #{sha} --pretty='(%ar)%n%B' --shortstat`
   puts
   puts
 

--- a/git-game
+++ b/git-game
@@ -28,28 +28,42 @@ def print_help
 end
 
 # -- Usage Text --
-if ARGV.count.positive? && (input = ARGV.shift) == 'help'
-  print_header
-  print_help
-  exit 0
+input = nil
+if ARGV.count.positive?
+  input = ARGV.shift
+
+  case input
+  when 'help'
+    print_header
+    print_help
+    exit 0
+  end
 end
 
 # -- Parse commits --
 COMMIT_DELIMITER = 'XXXCOMMITXXX'
-FIELD_DELIMITER = '|||'
+FIELD_DELIMITER = ',,,'
 
-commit_format = ['%an', '%ar', '%B'].join(FIELD_DELIMITER)
+commit_format = ['%aN', '%ar', '%B', ''].join(FIELD_DELIMITER)
 
-raw_commits = `git log --no-merges --pretty="#{COMMIT_DELIMITER}#{commit_format}" #{input}`.split(COMMIT_DELIMITER.to_s)
+raw_commits = `git log --no-merges --pretty=#{COMMIT_DELIMITER}#{commit_format} --shortstat #{input}`
+              .split(COMMIT_DELIMITER)
 commits = []
-raw_commits.each do |c|
-  next if c.strip.empty?
+committers = []
+raw_commits.each do |com|
+  next if com.strip.empty?
 
-  fields = c.split(FIELD_DELIMITER)
-  commits << { author: fields[0], date: fields[1], message: fields[2] }
+  fields = com.split(FIELD_DELIMITER)
+  next if fields.any?(&:empty?)
+
+  committers |= [fields[0]]
+  commits << {
+    author: fields[0],
+    date: fields[1],
+    message: fields[2],
+    stat: fields[3]
+  }
 end
-
-committers = commits.map { |c| c[:author] }.compact.uniq
 
 # -- Show welcome message --
 system('clear')
@@ -73,13 +87,12 @@ NUM_CHOICE = 4
 
 loop do
   commit = commits.shuffle.pop
-  message = commit[:message]
   author = commit[:author]
 
-  next if message.nil? || message.empty? || author.nil? || author.empty?
-
   puts "(#{commit[:date]})\n"
-  puts "#{message.strip}\n\n"
+  puts commit[:message]
+  puts commit[:stat]
+  puts
   puts
 
   choices = committers.sample(NUM_CHOICE)

--- a/git-game
+++ b/git-game
@@ -1,6 +1,8 @@
 #!/usr/bin/ruby
 # frozen_string_literal: true
 
+require 'English'
+
 longest_streak = streak = 0
 
 # -- Exit gracefully --
@@ -49,6 +51,7 @@ end
 commit_shas = `git log --no-merges --pretty=%H -z #{input}`
               .split("\0")
               .shuffle
+exit $CHILD_STATUS.exitstatus unless $CHILD_STATUS.success?
 committers = `git log --no-merges --pretty=%aN | sort -u`
              .split("\n")
 

--- a/git-game
+++ b/git-game
@@ -54,6 +54,7 @@ commit_shas = `git log --no-merges --pretty=%H -z #{input}`
 exit $CHILD_STATUS.exitstatus unless $CHILD_STATUS.success?
 committers = `git log --no-merges --pretty=%aN | sort -u`
              .split("\n")
+             .map(&:strip)
 
 # -- Show welcome message --
 system('clear')
@@ -83,8 +84,9 @@ commit_shas.each do |sha|
   choices += committers.reject do |name|
     name == author
   end.sample(NUM_CHOICE - 1)
+  choices.shuffle!
 
-  choices.shuffle.each_with_index do |name, index|
+  choices.each_with_index do |name, index|
     puts "[#{index + 1}] #{name}"
   end
 
@@ -104,7 +106,8 @@ commit_shas.each do |sha|
 
   longest_streak = [longest_streak, streak].max
 
-  sleep 1
+  puts "\nEnter to go to next question"
+  gets
   system('clear')
 end
 

--- a/git-game
+++ b/git-game
@@ -1,51 +1,52 @@
 #!/usr/bin/ruby
+# frozen_string_literal: true
 
 longest_streak = streak = 0
 
 # -- Exit gracefully --
-Signal.trap("INT") {
+Signal.trap('INT') do
   puts "\nLongest streak: #{longest_streak}"
   exit 0
-}
+end
 
 def print_header
-  puts "----------------------------------------------------------"
-  puts "                      THE GIT GAME                        "
-  puts "----------------------------------------------------------"
-  puts "Welcome! The goal of the git game is to guess committers"
+  puts '----------------------------------------------------------'
+  puts '                      THE GIT GAME                        '
+  puts '----------------------------------------------------------'
+  puts 'Welcome! The goal of the git game is to guess committers'
   puts "based on their commit messages.\n\n"
 end
 
 def print_help
-  puts "----------------------------------------------------------"
-  puts "                          USAGE                           "
-  puts "----------------------------------------------------------"
-  puts "git game [extra git log options]"
-  puts "EX: git game --after={2014-08-08}"
-  puts "(This script already uses --no-merges and --pretty."
-  puts "For more valid options see: http://gitref.org/inspect/)"
+  puts '----------------------------------------------------------'
+  puts '                          USAGE                           '
+  puts '----------------------------------------------------------'
+  puts 'git game [extra git log options]'
+  puts 'EX: git game --after={2014-08-08}'
+  puts '(This script already uses --no-merges and --pretty.'
+  puts 'For more valid options see: http://gitref.org/inspect/)'
 end
 
 # -- Usage Text --
-if ARGV.count > 0 && (input = ARGV.shift) == 'help'
+if ARGV.count.positive? && (input = ARGV.shift) == 'help'
   print_header
   print_help
   exit 0
 end
 
 # -- Parse commits --
-COMMIT_DELIMITER = "XXXCOMMITXXX"
-FIELD_DELIMITER = "|||"
+COMMIT_DELIMITER = 'XXXCOMMITXXX'
+FIELD_DELIMITER = '|||'
 
-commit_format = ["%an", "%ar", "%B"].join(FIELD_DELIMITER)
+commit_format = ['%an', '%ar', '%B'].join(FIELD_DELIMITER)
 
-raw_commits = `git log --no-merges --pretty="#{COMMIT_DELIMITER}#{commit_format}" #{input if input}`.split("#{COMMIT_DELIMITER}")
+raw_commits = `git log --no-merges --pretty="#{COMMIT_DELIMITER}#{commit_format}" #{input}`.split(COMMIT_DELIMITER.to_s)
 commits = []
 raw_commits.each do |c|
   next if c.strip.empty?
 
   fields = c.split(FIELD_DELIMITER)
-  commits << {:author => fields[0], :date => fields[1], :message => fields[2]}
+  commits << { author: fields[0], date: fields[1], message: fields[2] }
 end
 
 committers = commits.map { |c| c[:author] }.compact.uniq
@@ -61,7 +62,7 @@ committers.each do |committer|
   puts committer
 end
 
-puts "Ready? PRESS ENTER TO START PLAYING (Ctrl-C to quit)"
+puts 'Ready? PRESS ENTER TO START PLAYING (Ctrl-C to quit)'
 
 gets
 
@@ -82,7 +83,7 @@ loop do
   puts
 
   choices = committers.sample(NUM_CHOICE)
-  if !choices.include?(author)
+  unless choices.include?(author)
     choices.pop
     choices.push author
   end
@@ -103,7 +104,7 @@ loop do
 
   if choices[guess.to_i - 1] == author
     streak += 1
-    puts "Got it!"
+    puts 'Got it!'
   else
     streak = 0
     puts "Actually, it was #{author}."

--- a/git-game
+++ b/git-game
@@ -31,8 +31,8 @@ def print_help
     git game [options]
 
     Flags:
-      -h, --help      Show this help message
-      --hard          Opt into a challenge (git game classic)
+      -h          Show this help message
+      --hard      Opt into a challenge (git game classic)
 
     Extra options can be passed directly to git log:
 


### PR DESCRIPTION
# Fixes and Features

I really enjoyed this game and have put together this PR in hopes of addressing all of the issues I found while playing. **The main issue is mailmap support**. Let me know what you think. :)

## Fixes
### Use name defined in mailmap
See: [Git - git-log Documentation author name](https://git-scm.com/docs/git-log#Documentation/git-log.txt-emaNem)

To utilize the local mailmap definition of committers the `--pretty` format string must use `%aN`.

This resolves #19 

---
### Handle bad input
Git game will exit if git itself cannot handle the custom input provided.

![image](https://user-images.githubusercontent.com/31706913/235336396-2a07bd10-010a-4335-a217-7b0d61afa6b0.png)

This is similar to #30 

---
### Use up to date Git documentation links
Used in README and help text

Dead link: http://gitref.org/inspect/
Official documentation: https://git-scm.com/docs/git-log

---
### Accept a variety of help args
`git game --help` and `git game -h` now accepted

![image](https://user-images.githubusercontent.com/31706913/235336833-55fa6ef8-e6a7-4395-887e-cc598fbeb4a2.png)

## New Features

----
### Commit stats
Along with name and date, show a short description of changes.

![image](https://user-images.githubusercontent.com/31706913/235335659-08fabd1c-f093-45c6-ae81-7761659597c0.png)

---
### End the game when all commits have been shown
Git game will exit once all commits have been shown, congratulating the user and showing longest streak.

![image](https://user-images.githubusercontent.com/31706913/235336494-8d3f7eaf-f51c-4b36-8e44-a42c6ab021a7.png)

This is similar to #30 

---
### Prompt user to move on to next question
> Enter to go to next question

This is based on feedback I got from friends that the game moves a little too fast.

![image](https://user-images.githubusercontent.com/31706913/235335886-d83ae313-1ab5-4ecc-a963-e05ead62b47e.png)

