### PR TITLE
Linux Support Patch

### DIFF
--- a/git-game
+++ b/git-game
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require 'English'


### PR DESCRIPTION
`env` searches for where `ruby` was installed to instead of assuming it is in the same place on all *nixes

Based on feedback given on my draft git-game version bump. https://github.com/Homebrew/homebrew-core/pull/130933#discussion_r1199072729

Tested using the official Homebrew Linux docker container:
- Install Docker Desktop, and the Docker CLI
```sh
docker run --interactive --tty --rm --pull always homebrew/ubuntu22.04:latest /bin/bash
git clone https://github.com/jsomers/git-game.git
cd git-game
git checkout dgr/linux-support-patch
sudo cp git-game /usr/local/bin
sudo apt-get update
sudo apt-get install ruby
git game help
```